### PR TITLE
Correct less-than symbol on Pagination page

### DIFF
--- a/sections/pagination.md
+++ b/sections/pagination.md
@@ -5,8 +5,8 @@ APIs **SHOULD** follow a "pagination first" policy.
 
 Pagination is **RECOMMENDED** to:
 
-1. serve requests in a timely manner (e.g. > 2s)
-2. ensure the amount of data returned remains within a manageable payload (e.g. > 500kb)
+1. serve requests in a timely manner (e.g. < 2s)
+2. ensure the amount of data returned remains within a manageable payload (e.g. < 500kb)
 3. ensure the data in the response is easily manageable to improve the user experience.
 
 ## Query Parameters


### PR DESCRIPTION
The symbol on the page was incorrect (it previously read `>`, greater-than). This PR corrects this and in the process resolves #27 