### PR TITLE
Correct URL to pagination query parameters

### DIFF
--- a/sections/query-parameters.md
+++ b/sections/query-parameters.md
@@ -5,7 +5,7 @@ ______________________________________________________________________________
 
 Pagination is the process of returning a large set of results in chunks (or pages) to reduce the amount of information that is sent with each request.
 
-Pagination requires multiple query parameters to be provided, and further information about how to set this up is provided in the [pagination section](query-parameters.html#pagination) of this document.
+Pagination requires multiple query parameters to be provided, and further information about how to set this up is provided in the [pagination section](pagination.html#query-parameters) of this document.
 
 ## Filtering and Sorting
 


### PR DESCRIPTION
In the Pagination heading of the `query-parameters.html` page, there is a link which should take you to the pagination query parameters. Currently, the target of the link is the same page the link is on (ie, no operation). 

This PR corrects the link to go to the intended page (pagination.html, query parameters heading). This resolves #6 