### PR TITLE
update description for X-API-Retire-Time

### DIFF
--- a/sections/api-versioning.md
+++ b/sections/api-versioning.md
@@ -154,7 +154,7 @@ Justification **SHOULD** include the following:
 When a newer API is available API Owners are **RECOMMENDED** to provide two headers in the response when old versions are used:
 
 - X-API-Deprecated - boolean field advising that this has been deprecated
-- X-API-Retire-Time - ISO8601 date advising when it will be deprecated
+- X-API-Retire-Time - ISO8601 date advising when it will be retired
 
 For example:
 


### PR DESCRIPTION
As the X-API-Retire-Time is the date the that the deprecated version will be retired, this update makes it clearer.