### PR TITLE
query-parameters.md standards alignment

### DIFF
--- a/sections/query-parameters.md
+++ b/sections/query-parameters.md
@@ -53,7 +53,7 @@ The equal (=) operator is the only supported operator when used in this techniqu
 
 There are situations where simple filtering does not meet the needs and a more comprehensive approach is required. Use the reserved keyword 'filter' to define a more complex filtering logic.
 
-Complex filter logic can be chained together in a single 'filter' value, using OData query compliant query strings.
+Complex filter logic can be chained together in a single 'filter' value, using OData 4.0 query compliant query strings.
 
 The following operators should supported at a minimum:
 

--- a/sections/query-parameters.md
+++ b/sections/query-parameters.md
@@ -19,12 +19,12 @@ Below are the different techniques used when applying filtering and sorting:
 
 ### Output Selection
 
-Consumers can specify the attributes they wish to return in the [response payload](api-response.html#response-payload) by specifying the attributes in the [query parameters](pagination.html#query-parameters).
+Consumers can specify the fields they wish to return in the [response payload](api-response.html#response-payload) by specifying the fields in the [query parameters](pagination.html#query-parameters).
 
 Example that returns only the `first_name` and `last_name` fields in the response.
 
 ```
-?attributes=first_name,last_name
+?fields=first_name,last_name
 ```
 
 ### Simple Filtering
@@ -71,7 +71,7 @@ The AND, OR conditions are supported.
 Example:
 
 ```
-?filters=creation_date =\> 2001-09-20T13:00:00 and creation_date \<= 2001-09-21T13:00:00 and first_name like 'fred' and post_code=3000
+?filter=creation_date =\> 2001-09-20T13:00:00 and creation_date \<= 2001-09-21T13:00:00 and first_name like 'fred' and post_code=3000
 ```
 
 Return a collection of resources where the `creation_date` is between `2001-09-20 1pm` and `2001-09-21 1pm` and `first-name` like "fred" and `post_code` is 3000.

--- a/sections/query-parameters.md
+++ b/sections/query-parameters.md
@@ -71,10 +71,10 @@ The AND, OR conditions are supported.
 Example:
 
 ```
-?filter=creation_date =\> 2001-09-20T13:00:00 and creation_date \<= 2001-09-21T13:00:00 and first_name like 'fred' and post_code=3000
+?filter=creation_date gt 2001-09-20T13:00:00 and creation_date lt 2001-09-21T13:00:00 and post_code eq 3000
 ```
 
-Return a collection of resources where the `creation_date` is between `2001-09-20 1pm` and `2001-09-21 1pm` and `first-name` like "fred" and `post_code` is 3000.
+Return a collection of resources where the `creation_date` is between `2001-09-20 1pm` and `2001-09-21 1pm` and `post_code` is 3000.
 
 ### Match Case Sensitivity
 

--- a/sections/query-parameters.md
+++ b/sections/query-parameters.md
@@ -51,22 +51,20 @@ The equal (=) operator is the only supported operator when used in this techniqu
 
 ### Advanced Filtering
 
-There are situations where simple filtering does not meet the needs and a more comprehensive approach is required. Use the reserved keyword filters to define a more complex filtering logic.
+There are situations where simple filtering does not meet the needs and a more comprehensive approach is required. Use the reserved keyword 'filter' to define a more complex filtering logic.
 
-Multiple attributes with different operator and condition can be defined in the filter query parameter.
+Complex filter logic can be chained together in a single 'filter' value, using OData query compliant query strings.
 
-The following operators are supported:
+The following operators should supported at a minimum:
 
-  1. \>= Greater than or equalled to
-  2. => Equalled to or greater than
-  3. \> Greater than
-  4. < Less than
-  5. <= Less than or equalled to
-  6. =< Equalled to or less than
-  7. = Equalled
-  8. != Not equalled
+  1. gt - Greater than
+  2. lt - Less than
+  3. ge - Greater than or equal to
+  5. le - Less than or equal to
+  7. eq - Equal
+  8. ne - Not equal
 
-The AND, OR conditions are supported.
+The 'and', 'or' conditions shoud be supported.
 
 Example:
 


### PR DESCRIPTION
Update query-parameters.md filtering and output selection keyword to align with previous DTA standards and current international gov API standards.

The ‘attributes’ keyword is an unusual choice for output selection. Sparse fieldsets (‘fields’) is a flexible, widely used and well understood mechanism (Google, JSON-API), and is used in the previous DTA API standards, the WhiteHouse API standards and the NZ gov API standards. The fields keyword does not rely on dependant keywords, and 'plays nicely' with multiple independent parameters. ‘filter’ (rather than 'filters') is a prevalent industry standard (Microsoft, Google, OData), and should use OData syntax to support existing filter string parsing libraries, negate the need to escape reserved chars, and disambiguate the '=' char.
Issue #25 Issue #42 Issue #43 