### PR TITLE
Addition of Protective Marking sub-section to api-security.md

### DIFF
--- a/sections/api-security.md
+++ b/sections/api-security.md
@@ -136,9 +136,9 @@ Protective marking allows entities correctly assess the sensitivity or security 
 
 The following rules apply to the use of the ‘x-protective-marking’ header:
 -	Transmission of any payload, request or response, containing data classified as having a high business impact level or above SHOULD apply by an ‘x-protective-marking’ HTTP header.
--	An ‘x-protective-marking’ HTTP header MUST be used to apply appropriate protective marking to Commonwealth information classified as having a high business impact level or above (classification of ‘PROTECTED’).
+-	An ‘x-protective-marking’ HTTP header MUST be used to apply appropriate protective marking to Commonwealth information classified as having a high business impact level or above (classification of ‘PROTECTED’), and SHOULD be applied to Commonwealth information classified as having a medium business impact level.
 
-The format of the ‘x-protective-marking’ should follow the following format at a minimum, with additional optional semantics defined per jurisdiction:
+The ‘x-protective-marking’ header should follow the following format, with additional optional semantics defined per jurisdiction:
 
 **Syntax**
 ```

--- a/sections/api-security.md
+++ b/sections/api-security.md
@@ -132,28 +132,32 @@ The WoG API Team can provide advice on which API Gateway security policies shoul
 
 ## Protective Marking
 
-Protective marking allows entities correctly assess the sensitivity or security classification of their information and adopt marking, handling, storage and disposal arrangements that guard against information compromise. The semantics and syntax may be unique to individual jurisdictions.
+Protective marking allows entities correctly assess the sensitivity or security classification of their information and adopt marking, handling, storage and disposal arrangements that guard against information compromise. Classification semantics may be unique to individual jurisdictions.
 
 The following rules apply to the use of the ‘x-protective-marking’ header:
 -	Transmission of any payload, request or response, containing data classified as having a high business impact level or above SHOULD apply by an ‘x-protective-marking’ HTTP header.
 -	An ‘x-protective-marking’ HTTP header MUST be used to apply appropriate protective marking to Commonwealth information classified as having a high business impact level or above (classification of ‘PROTECTED’).
 
-For Commonwealth data, the values (and case) of the header should align with the appropriate Security classification literals defined in the [Protective Security Policy Framework](https://www.protectivesecurity.gov.au/information/sensitive-classified-information/Pages/default.aspx), and conforming to the syntax prescribed in the [Annex B Email protective marking standard](https://www.protectivesecurity.gov.au/sites/default/files/2019-09/infosec08-sensitive-and-classified-information-email.pdf). 
+The format of the ‘x-protective-marking’ should follow the following format at a minimum, with additional optional semantics defined per jurisdiction:
 
 **Syntax**
 ```
-X-Protective-Marking: VER=<ver>, NS=gov.au, SEC=<securityClassification>(, CAVEAT=<caveatType>:<caveatValue>)*(, EXPIRES=(<genDate>|<event>), DOWNTO=(<securityClassification>))?(, ACCESS=<InformationManagementMarker>)*
+X-Protective-Marking: VER=<ver>, NS=gov.au, SEC=<securityClassification>
 ```
 
-In the case of Commonwealth security classified information, the first 2 key-value pairs are largely static. The namespace ('NS') value is always 'gov.au' when produced by Australian Government entities. The version (‘VER’) of the PSPF will change infrequently. The first key-value pair appended to the x-protective-marking header will be the classification version (currently 'VER=2018.1') and the second key-value pair the Australian Government namespace ('NS=gov.au'). The security classification marker and further optional markings follow.
+The first 2 key-value pairs of a security classification scheme are largely static. The first key-value pair appended to the x-protective-marking header will be the classification version, which is backward compatible and should change infrequently. The second key-value pair is the classification scheme namespace. The security classification marker (and further optional markings) follow.
 
 e.g.
 
 `    x-protective-marking: VER=2018.1, NS=gov.au, SEC=PROTECTED`
 
-or 
 
- `   x-protective-marking: VER=2018.1, NS=gov.au, SEC=OFFICIAL:Sensitive, ACCESS=Personal-Privacy`
+For Commonwealth data, the values (and case) of the header should use the Australian Government (gov.au) namespace and align with the appropriate Security classification literals defined in the [Protective Security Policy Framework](https://www.protectivesecurity.gov.au/information/sensitive-classified-information/Pages/default.aspx), and conforming to the syntax prescribed in the [Annex B Email protective marking standard](https://www.protectivesecurity.gov.au/sites/default/files/2019-09/infosec08-sensitive-and-classified-information-email.pdf). 
+
+**Syntax**
+```
+X-Protective-Marking: VER=<ver>, NS=gov.au, SEC=<securityClassification>(, CAVEAT=<caveatType>:<caveatValue>)*(, EXPIRES=(<genDate>|<event>), DOWNTO=(<securityClassification>))?(, ACCESS=<InformationManagementMarker>)*
+```
 
 State or territory governments may use the Australian Government (gov.au) namespace and semantics, or they may use a their own namespace value (different from the Australian Government) and apply rules specific to their jurisdiction.
 

--- a/sections/api-security.md
+++ b/sections/api-security.md
@@ -129,3 +129,32 @@ It is preferable to use the security policy features available in the WoG API Ga
 | CORS | Listeners-\>Path | CORS can be restricted at path level | Recommended |
 
 The WoG API Team can provide advice on which API Gateway security policies should be applied.
+
+## Protective Marking
+
+Protective marking allows entities correctly assess the sensitivity or security classification of their information and adopt marking, handling, storage and disposal arrangements that guard against information compromise. The semantics and syntax may be unique to individual jurisdictions.
+
+The following rules apply to the use of the ‘x-protective-marking’ header:
+-	Transmission of any payload, request or response, containing data classified as having a high business impact level or above SHOULD apply by an ‘x-protective-marking’ HTTP header.
+-	An ‘x-protective-marking’ HTTP header MUST be used to apply appropriate protective marking to Commonwealth information classified as having a high business impact level or above (classification of ‘PROTECTED’).
+
+For Commonwealth data, the values (and case) of the header should align with the appropriate Security classification literals defined in the [Protective Security Policy Framework](https://www.protectivesecurity.gov.au/information/sensitive-classified-information/Pages/default.aspx), and conforming to the syntax prescribed in the [Annex B Email protective marking standard](https://www.protectivesecurity.gov.au/sites/default/files/2019-09/infosec08-sensitive-and-classified-information-email.pdf). 
+
+**Syntax**
+```
+X-Protective-Marking: VER=<ver>, NS=gov.au, SEC=<securityClassification>(, CAVEAT=<caveatType>:<caveatValue>)*(, EXPIRES=(<genDate>|<event>), DOWNTO=(<securityClassification>))?(, ACCESS=<InformationManagementMarker>)*
+```
+
+In the case of Commonwealth security classified information, the first 2 key-value pairs are largely static. The namespace ('NS') value is always 'gov.au' when produced by Australian Government entities. The version (‘VER’) of the PSPF will change infrequently. The first key-value pair appended to the x-protective-marking header will be the classification version (currently 'VER=2018.1') and the second key-value pair the Australian Government namespace ('NS=gov.au'). The security classification marker and further optional markings follow.
+
+e.g.
+
+`    x-protective-marking: VER=2018.1, NS=gov.au, SEC=PROTECTED`
+
+or 
+
+ `   x-protective-marking: VER=2018.1, NS=gov.au, SEC=OFFICIAL:Sensitive, ACCESS=Personal-Privacy`
+
+State or territory governments may use the Australian Government (gov.au) namespace and semantics, or they may use a their own namespace value (different from the Australian Government) and apply rules specific to their jurisdiction.
+
+Content (payload) classified as having a high business impact level or above MUST NOT be logged, unless over secure channels and to platforms approved for the retention of data to the appropriate classification. 

--- a/sections/api-security.md
+++ b/sections/api-security.md
@@ -134,8 +134,8 @@ The WoG API Team can provide advice on which API Gateway security policies shoul
 
 Protective marking allows entities correctly assess the sensitivity or security classification of their information and adopt marking, handling, storage and disposal arrangements that guard against information compromise. Classification semantics may be unique to individual jurisdictions.
 
-The following rules apply to the use of the ‘x-protective-marking’ header:
--	Transmission of any payload, request or response, containing data classified as having a high business impact level or above SHOULD apply by an ‘x-protective-marking’ HTTP header.
+An ‘x-protective-marking’ header should be used to apply data classification. The following rules apply to the use of the ‘x-protective-marking’ header:
+-	Transmission of any payload, request or response, containing data classified as having a high business impact level or above SHOULD be accompanied by an ‘x-protective-marking’ HTTP header.
 -	An ‘x-protective-marking’ HTTP header MUST be used to apply appropriate protective marking to Commonwealth information classified as having a high business impact level or above (classification of ‘PROTECTED’), and SHOULD be applied to Commonwealth information classified as having a medium business impact level.
 
 The ‘x-protective-marking’ header should follow the following format, with additional optional semantics defined per jurisdiction:

--- a/sections/api-security.md
+++ b/sections/api-security.md
@@ -145,7 +145,7 @@ The ‘x-protective-marking’ header should follow the following format, with a
 X-Protective-Marking: VER=<ver>, NS=<namespace>, SEC=<securityClassification>
 ```
 
-The first 2 key-value pairs of a security classification scheme are largely static for a specific REST resource. The first key-value pair appended to the x-protective-marking header will be the classification version, which is backward compatible and should change infrequently. The second key-value pair is the classification scheme namespace. The security classification marker (and further optional markings) follow.
+The first key-value pair appended to the x-protective-marking header will be the classification version, which is backward compatible and should change infrequently. The second key-value pair is the classification scheme namespace. The security classification marker (and further optional markings) follow.
 
 e.g.
 

--- a/sections/api-security.md
+++ b/sections/api-security.md
@@ -142,7 +142,7 @@ The ‘x-protective-marking’ header should follow the following format, with a
 
 **Syntax**
 ```
-X-Protective-Marking: VER=<ver>, NS=gov.au, SEC=<securityClassification>
+X-Protective-Marking: VER=<ver>, NS=<namespace>, SEC=<securityClassification>
 ```
 
 The first 2 key-value pairs of a security classification scheme are largely static. The first key-value pair appended to the x-protective-marking header will be the classification version, which is backward compatible and should change infrequently. The second key-value pair is the classification scheme namespace. The security classification marker (and further optional markings) follow.

--- a/sections/api-security.md
+++ b/sections/api-security.md
@@ -152,7 +152,7 @@ e.g.
 `    x-protective-marking: VER=2018.1, NS=gov.au, SEC=PROTECTED`
 
 
-For Commonwealth data, the values (and case) of the header should use the Australian Government (gov.au) namespace and align with the appropriate Security classification literals defined in the [Protective Security Policy Framework](https://www.protectivesecurity.gov.au/information/sensitive-classified-information/Pages/default.aspx), and conforming to the syntax prescribed in the [Annex B Email protective marking standard](https://www.protectivesecurity.gov.au/sites/default/files/2019-09/infosec08-sensitive-and-classified-information-email.pdf). 
+For Commonwealth data the Australian Government (gov.au) namespace should be used, and the values (and case) of the header should align with the appropriate Security classification literals defined in the [Protective Security Policy Framework](https://www.protectivesecurity.gov.au/information/sensitive-classified-information/Pages/default.aspx), and conforming to the syntax prescribed in the [Annex B Email protective marking standard](https://www.protectivesecurity.gov.au/sites/default/files/2019-09/infosec08-sensitive-and-classified-information-email.pdf). 
 
 **Syntax**
 ```

--- a/sections/api-security.md
+++ b/sections/api-security.md
@@ -138,14 +138,14 @@ An ‘x-protective-marking’ header should be used to apply data classification
 -	Transmission of any payload, request or response, containing data classified as having a high business impact level or above SHOULD be accompanied by an ‘x-protective-marking’ HTTP header.
 -	An ‘x-protective-marking’ HTTP header MUST be used to apply appropriate protective marking to Commonwealth information classified as having a high business impact level or above (classification of ‘PROTECTED’), and SHOULD be applied to Commonwealth information classified as having a medium business impact level.
 
-The ‘x-protective-marking’ header should follow the following format, with additional optional semantics defined per jurisdiction:
+The content of the ‘x-protective-marking’ header should follow the following format, with additional optional semantics defined per jurisdiction:
 
 **Syntax**
 ```
 X-Protective-Marking: VER=<ver>, NS=<namespace>, SEC=<securityClassification>
 ```
 
-The first key-value pair appended to the x-protective-marking header will be the classification version, which is backward compatible and should change infrequently. The second key-value pair is the classification scheme namespace. The security classification marker (and further optional markings) follow.
+The first key-value pair will be the classification version, which is backward compatible and should change infrequently. The second key-value pair is the classification scheme namespace. The security classification marker (and further optional markings) follow.
 
 e.g.
 

--- a/sections/api-security.md
+++ b/sections/api-security.md
@@ -145,7 +145,7 @@ The ‘x-protective-marking’ header should follow the following format, with a
 X-Protective-Marking: VER=<ver>, NS=<namespace>, SEC=<securityClassification>
 ```
 
-The first 2 key-value pairs of a security classification scheme are largely static. The first key-value pair appended to the x-protective-marking header will be the classification version, which is backward compatible and should change infrequently. The second key-value pair is the classification scheme namespace. The security classification marker (and further optional markings) follow.
+The first 2 key-value pairs of a security classification scheme are largely static for a specific REST resource. The first key-value pair appended to the x-protective-marking header will be the classification version, which is backward compatible and should change infrequently. The second key-value pair is the classification scheme namespace. The security classification marker (and further optional markings) follow.
 
 e.g.
 

--- a/sections/api-security.md
+++ b/sections/api-security.md
@@ -11,7 +11,7 @@ At minimum the security standards that are defined here **MUST** be applied. Fur
 
 ## Transport Security
 
-- ALL transport **MUST** occur over HTTPS using TLS 1.2.
+- ALL transport **MUST** occur over HTTPS using at least TLS 1.2.
 - ALL certificates **MUST** be from SHA-2 (Secure Hash Algorithm 2) cryptographic hash functions with minimum key length of 2048.
 - ALL publicly accessible endpoints **MUST** use a Digital Certificate that has been signed by an approved Certificate Authority.
 - Internal facing endpoints **MAY** use self-signed Digital Certificates.

--- a/sections/definitions.md
+++ b/sections/definitions.md
@@ -1,97 +1,131 @@
 ______________________________________________________________________________
-# Definitions
+# API Security
 
-## API
+## API Design
 
-In the context of this API Design Standard, an API (Application Programming Interface) is defined as a RESTful API.  
+Applying the right level of security will allow your APIs to perform well without compromising on the security risk.
 
-A RESTful API is a style of communication between systems where resources are defined by URI and its operations are defined by the use of HTTP methods.
+To secure your APIs the security standards are grouped into three categories: Design, Transport, and Authentication & Authorisation.
 
-A RESTful API adopts many HTTP standards such as response codes and methods.
+At minimum the security standards that are defined here **MUST** be applied. Further security considerations may apply depending on the API design and requirements – refer to our [API Design Considerations section](getting-started.html#how-to-apply-the-design-standard) for more details.
 
-## Resource
+## Transport Security
 
-In order to design a useful and clean API your system should be broken down into logical groupings (often called Models or Resources). In most cases the resources are the 'nouns' of your system.
+- ALL transport **MUST** occur over HTTPS using TLS 1.2.
+- ALL certificates **MUST** be from SHA-2 (Secure Hash Algorithm 2) cryptographic hash functions with minimum key length of 2048.
+- ALL publicly accessible endpoints **MUST** use a Digital Certificate that has been signed by an approved Certificate Authority.
+- Internal facing endpoints **MAY** use self-signed Digital Certificates.
+- Do not redirect HTTP traffic to HTTPS - reject these requests
+- Unused HTTP methods **SHOULD** be disabled and return HTTP 405.
+- ALL requests must be validated.
 
-In the example of an HR system, the resources are `employees`, `positions` and `leave-requests`.
+Depending on the security classification you may be required to establish the following controls above and beyond the standard controls:
 
-By breaking systems down into these logical areas it allows a clean separation of concerns (e.g. employee functions only work on `employees` and only `employees` can apply for `leave-requests`).  It also ensures that each piece of data that is returned from your API is the smallest that it needs to be to fulfil the client requirement (e.g. when asking for `employees` you don't also receive back `family-members`).
+- Mutual authentication between the consumer and the API Gateway
+- Mutual authentication between the API Gateway and the back-end API
+- IP Whitelisting of API Consumers using either API Gateway Policy or Firewall configurations
+- IP Whitelisting of API Publishers using either API Gateway Policy or Firewall configurations
+- Payload encryption while in transit
+- Payload signing for integrity and verification
 
-## Resource Identifier
+## Authentication and Authorization
 
-Every resource that is available within your system (e.g. every employee or every leave-request) must be identifiable uniquely within the system. This is a key element of the RESTful style of APIs; the ability to individually address any item within your system and store these identifiers for later use.
+- Basic or Digest authentication **SHOULD NOT**  be used.
+- The `Authorization: Bearer` header **MUST** be used for authentication/authorization e.g. using a JWT token.
+- A refresh token **SHOULD** be provided for extending expiry time of existing token without having to provide the credentials again. 
+- Always set a reasonable expiration date for tokens. JWT token lifetime **SHOULD NOT*** exceed 5 minutes.
+- JWT refresh tokens **SHOULD** be used when new JWT tokens are required outside of this lifetime. 
+- All APIs **MUST** have a policy that only allows access based on a valid API key.
+- API keys **MUST** be used for client authentication. Use of API keys should only be permitted when TLS is enabled. Rotation policy for API Key should be implemented as well.
+- API keys **SHOULD NOT** be included in the URL or query string. API keys **SHOULD** be included in the HTTP header as query strings may be saved by the client or server in unencrypted format by the browser or server application. 
+- CORS headers should only be used when necessary as it reduces the overall security mechanisms built into web browsers by selectively relaxing cross-origin restrictions.
+- A request from Domain A is considered cross-origin when it tries to make a request to an API that is hosted in Domain B.
+  - For security reasons, browsers restrict cross-origin HTTP requests.
+  - The Cross-Origin Resource Sharing standard works by adding new HTTP headers (i.e. Access-Control-Allow-Origin) that allow servers to describe the set of origins that are permitted to access the API
+- Never use wildcard (\*) URLs in the response headers (i.e. Access-Control-Allow-Origin) unless the REST resource is truly public and requires little or no authorization for use.
 
-Resource identifiers can be any of the following:
+### TDIF
 
-Name | Example
--- | --
-Numeric | /employees/6df5a5e569a4
-String | /country-codes/australia
-GUID | /employees/0d047d80-eb69-4665-9395-6df5a5e569a4
-Date (Short form) | /dates/2018-09-17
+TDIF ( Trusted Digital Identity Framework ) forms the basis of single-sign-on (SSO) user authentication for citizens to access government services across Australia. Through a series of double-blind identity exchanges, it provides a federated approach to SSO that allows user choice in terms of identity provider, as well as attribute provider capabilities. It is currently being developed at state level with states either building their own identity exchange or using the federal identity exchange. It supports OpenID Connect and SAML 2.0 - OpenID Connect is built on top of OAuth 2.0.
+ref: https://www.dta.gov.au/our-projects/digital-identity/trusted-digital-identity-framework
 
-As long as the identifier is unique within your application it can be any string of characters or numbers.
+### OAuth 2.0
 
-The resource identifier MUST be immutable. Primary keys or Personally Identifiable Information (PII) MUST NOT be exposed. When numeric IDs are used they MUST NOT be sequential e.g. it should not be trivial to guess the next ID. If this is difficult to achieve, then it is likely the API needs to be further abstracted from the underlying data source. 
+OAuth 2.0 can be used for authorisation. OAuth is an authorisation protocol that securely delegates authorisation to another resource. It allows users to approve applications to act on their behalf without sharing their password.
 
-## Representation
+OpenID Connect extends the OAuth 2.0 protocol to receive information about the authenticated users such as their username and is useful when dealing with federated identity providers.
 
-A key concept in RESTful API design is the idea of the representation of a resource at any particular time.
+The API Team provides an OAuth service that can be used by WoG APIs.  Alternatively, API Providers can link into Open ID Providers to delegate authorisation. This process can be facilitated by the WoG API Gateway.
 
-When you ask the system for employee information you will receive a representation of that employee e.g.
+## Abstraction
 
-```
-HTTP 1.1 GET /employees/6df5a5e569a4
-Accept: application/json
+There are multiple levels of abstraction and determining the level of abstraction is largely based on the number of consumers and the cost to change the system in response to an API change.
 
-200 OK
-Content-Type: application/json
+As a general principle there should be a level of abstraction of the source system data and business logic in your API design to decouple the consumers and the API service provider(s). Applying BASIC abstraction to a SaaS API (such as an Azure API) is recommended. For example; if there are changes in the SaaS authentication schema it could be handled within the API. 
 
-{
-  "name" : "John Smith",
-  "employeeId" : "6df5a5e569a4",
-  "position" : "Manager",
-  "onLeave" : false
-}
-```
+A higher level of abstraction would be required for APIs that have multiple consumers and the cost of change to the API consumers is greater than the cost to change the backend systems / service providers.
 
-The intent is this representation can change over time as the system and data within changes.  A future call to this same endpoint may yield a different representation possibly if the employee is now on leave or their position within the organisation has changed.
+The varying levels of abstraction are as follows:
 
-It is also possible to request an entirely different representation of this same resource if the system supports it.  For example, there may be a case where you require a PDF version of this employee and this could be facilitated with a request for a different representation through the `Accept` header:
+| Abstraction Level | Description |
+| --- | --- |
+| `BASIC` | **Basic abstraction level**  - represents the minimum abstraction required for all APIs (including point-to-point):  - Use `JSON` as your default representation.  - Always provide a version number in the URL to facilitate change.  - Always use an API Key ID  - Little or no abstraction of the Data model and expose data as required
+| `INTERMEDIATE` | APIs which aim for re-use should consider Intermediate levels of abstraction:  **Payload abstraction**  - Represent resources from the consumer view point and be independent of the underlying system. NEVER directly expose the internal database table structure as is in your API.  - Error abstraction  – Handle source system errors and represent the errors in a consistent and informative. **System IDs abstraction**  – Avoid exposing and sharing internal system identifiers (such as a database ID) with your consumers. Use a candidate key or a secondary identifier.
+| `ADVANCED` | The highest level of abstraction and it encompasses all the other levels. - Use the API Gateway pattern to take care of cross-cutting concerns such as security, traffic management and analytics/monitoring.  - Use Linked Data hypermedia to promote "discoverability" of your API resources and relationships.   - Consider using HATEOAS to abstract allowable actions.
 
-```
-HTTP 1.1 GET /employees/6df5a5e569a4
-Accept: application/pdf
+## Rate Limiting
 
-200 OK
-Content-Type: application/pdf
+Apply rate limiting and throttling policies to prevent abuse of your API. Ensure appropriate alerts are implemented and respond with informative errors when thresholds are nearing or have been exceeded.
 
-...<BINARY CODE>...
-```
+The following headers will be returned when rate limits are in place:
 
-More information about representations and how to support them is provided in the [Hypermedia](hypermedia.html) section of this document.
+| Header | Description |
+| --- | --- |
+| `X-Rate-Limit-Limit` | Rate limit ceiling for the given request (for example, 100 messages). |
+| `X-Rate-Limit-Remaining` | Number of requests left for the time window (for example, 45 messages). |
+| `X-Rate-Limit-Reset` | Remaining time window before the rate limit resets in UTC epoch seconds (for example, 1353517297). |
 
-## Namespace
+## Error Handling
 
-The namespace for a service defines the grouping of related functions within.  Namespaces could be quite high level (e.g. an agency or department name) or quite low level (e.g. a project, team or service being exposed).
+When your application displays error messages, it should not expose information that could be used to attack your system. You should establish the following controls when providing error messages:
 
-Namespaces are useful when providing consumers access to related functions through gateway technologies.  Once a consumer has an access token to a particular namespace it is likely (though not always required) that they will get access to all functions supplied within that namespace.
+- Your API **MUST** mask any system related errors behind standard HTTP status responses and error messages e.g. do not expose system level information in your error response
+- Your API **MUST NOT** pass technical details (e.g. call stacks or other internal hints) to the client
 
-Namespaces are relevant when designing your URL structure and are further covered in section [URI Component Names](naming-conventions.html#uri-component-names).
+## Audit Logs
 
-## Operation
+An important aspect of security is to be notified when something wrong occurs, and to be able to investigate it. It is **RECOMMENDED** to define the right level of logging and audit and to set the right alerts.
 
-To make use of any of the namespaces, resources and resource identifiers, developers must make use of Operations.
+- Write audit logs before and after security related events which can trigger the alerts
+- Sanitizing the log data to prevent log injection attacks
 
-An operation is defined by the use of:
+## Input Validation
 
-- an HTTP method; and
-- a resource path.
-  
-Examples:
+Input validation is performed to ensure only properly formed data is received by your system, this helps to prevent malicious attacks
 
-```
-GET /employees
-GET /employees/6df5a5e569a4
-DELETE /employees/6df5a5e569a4
-```
+- Input validation should happen as early as possible, preferably as soon as the data is received from the external party
+- Define an appropriate request size limit and reject requests exceeding the limit
+- Validate input: e.g. length / range / format and type
+- Consider logging input validation failures. Assume that someone who is performing hundreds of failed input validations per second has a malicious intent.
+- Constrain string inputs with regular expression where appropriate
+
+## Content Type Validation
+
+Honour the specified content-type. Reject requests containing unexpected or missing content type headers with HTTP response status `415 Unsupported Media Type`.
+
+## Gateway Security Features
+
+It is preferable to use the security policy features available in the WoG API Gateway platform than to implement the policies in your back-end API.
+
+| Security | API Gateway Component | Comment | Implementation Required |
+| --- | --- | --- | --- |
+| HTTP verbs | Listeners-\>Path | HTTP verbs can be selected when defining the path for the API | Recommended |
+| Input Validation | Filter -\> Content Filtering | Various filters can be used for validating the input i.e. message size, schema validation, validate headers, validate query strings etc. | Recommended |
+| SSL | Listeners | SSL protocol (i.e. TLS 1.2 etc.) can be selected at listener level | Recommended |
+| Digital Certificate | Filter -\> Integrity | Various filters can be used for creating and validating the signature i.e. XML signature, JWT sign | Optional depends on business requirements (Recommended algorithm is RS256) |
+| JWT | Filter -\> Integrity | Message can be signed using JWT | Optional depends on business requirements |
+| API Keys | Filter -\> Authentication | Various filters can be used for authenticating the consumers i.e. API Keys etc. | Recommended |
+| OAUTH | Filter -\> OAUTH | OAUTH can be used for authorizing the consumers | Optional as it depends on business requirements |
+| CORS | Listeners-\>Path | CORS can be restricted at path level | Recommended |
+
+The WoG API Team can provide advice on which API Gateway security policies should be applied.

--- a/sections/definitions.md
+++ b/sections/definitions.md
@@ -25,7 +25,7 @@ Resource identifiers can be any of the following:
 
 Name | Example
 -- | --
-Numeric | /employees/12389
+Numeric | /employees/6df5a5e569a4
 String | /country-codes/australia
 GUID | /employees/0d047d80-eb69-4665-9395-6df5a5e569a4
 Date (Short form) | /dates/2018-09-17
@@ -41,7 +41,7 @@ A key concept in RESTful API design is the idea of the representation of a resou
 When you ask the system for employee information you will receive a representation of that employee e.g.
 
 ```
-HTTP 1.1 GET /employees/john-smith
+HTTP 1.1 GET /employees/6df5a5e569a4
 Accept: application/json
 
 200 OK
@@ -49,9 +49,9 @@ Content-Type: application/json
 
 {
   "name" : "John Smith",
-  "employee_id" : "123456",
+  "employeeId" : "6df5a5e569a4",
   "position" : "Manager",
-  "on_leave" : false
+  "onLeave" : false
 }
 ```
 
@@ -60,7 +60,7 @@ The intent is this representation can change over time as the system and data wi
 It is also possible to request an entirely different representation of this same resource if the system supports it.  For example, there may be a case where you require a PDF version of this employee and this could be facilitated with a request for a different representation through the `Accept` header:
 
 ```
-HTTP 1.1 GET /employees/john-smith
+HTTP 1.1 GET /employees/6df5a5e569a4
 Accept: application/pdf
 
 200 OK


### PR DESCRIPTION
Addition of Protective Marking sub-section to API Security, as discussed Working Group July 27.
A unified approach to protective marking would greatly enhance API inter-operabilty. It is acknowledged that each jurisdiction may have similar requirements, and this section should be open to evolution.
Genericised version based on V1.1.