### PR TITLE
PROVISIONAL : CDS alignment -  top level members for canonical business information resources

### DIFF
--- a/sections/api-request.md
+++ b/sections/api-request.md
@@ -62,7 +62,7 @@ All APIs **MUST** support the following request headers:
 
 | Header | Value |
 | --- | --- |
-| Authorization / Identification | One of: <ul> <li> API Key </li> <li> Basic Auth (APIKey + Secret) </li> <li> Username + Password </li> <li> Bearer {token} </li></ul> |
+| Authorization | One of: <ul> <li> Basic Auth (API-Key + Secret) </li> <li> Username + Password </li> <li> Bearer {token} </li></ul> |
 
 The following request headers **SHOULD** be supported.
 
@@ -71,6 +71,7 @@ The following request headers **SHOULD** be supported.
 | Content-Type | A choice of: <ul> <li> `application/json` (required)</li> <li> `application/xml` (optional for xml)</li> <li> `multipart/form-data` (optional for files) </li> <li> `application/x-www-form-urlencoded` (optional for form data) </li> </ul> |
 | Accept | Content-Types that are acceptable for the response. Choice of: <ul> <li> `application/json` (required) </li> <li> `application/xml` (optional for xml) </li></ul> |
 | Request-Id | A unique identifier for the API request to assist with issue resolution |
+| API-Key | A unique client application identifier, usually issued by an API Developer portal |
 
 The following optional request headers **MAY** apply.
 

--- a/sections/api-request.md
+++ b/sections/api-request.md
@@ -81,7 +81,8 @@ The following optional request headers **MAY** apply.
 | Date | The date and time at which the message was originated, in "HTTP-date" format as defined by [RFC 7231 Date/Time Formats](http://tools.ietf.org/html/rfc7231#section-7.1.1.1). E.g. `Tue, 15 Nov 1994 08:12:31 GMT`.  |
 | Cookie | An HTTP cookie previously sent by the server. |
 | Cache-Control | Used to specify directives that must be obeyed by all caching mechanisms e.g. no-cache. |
-| If-None-Match | A string of ASCII characters placed between double quotes. Matches the content of the server-provided ‘Etag’ header. The client should include this in any update requests to ascertain whether the version of a resource is unchanged. |
+| If-Match | A string of ASCII characters placed between double quotes.Makes the request conditional. For GET and HEAD methods, the server will send back the requested resource only if it matches one of the listed ETags. For PUT and other non-safe methods, it will only upload the resource in this case.
+| If-None-Match | A string of ASCII characters placed between double quotes.  For GET and HEAD methods, the server will send back the requested resource, with a 200 status, only if it doesn't have an ETag matching the given ones. For other methods, the request will be processed only if the eventually existing resource's ETag doesn't match any of the values listed. |
 
 Payload data **MUST NOT** be transmitted via HTTP Headers. They are reserved for transversal information (authentication token, monitoring token, request properties etc).
 

--- a/sections/api-request.md
+++ b/sections/api-request.md
@@ -71,7 +71,7 @@ The following request headers **SHOULD** be supported.
 | Content-Type | A choice of: <ul> <li> `application/json` (required)</li> <li> `application/xml` (optional for xml)</li> <li> `multipart/form-data` (optional for files) </li> <li> `application/x-www-form-urlencoded` (optional for form data) </li> </ul> |
 | Accept | Content-Types that are acceptable for the response. Choice of: <ul> <li> `application/json` (required) </li> <li> `application/xml` (optional for xml) </li></ul> |
 | Request-Id | A unique identifier for the API request to assist with issue resolution |
-| API-Key | A unique client application identifier, usually issued by an API Developer portal |
+| API-Key | A unique client application identifier, usually issued by an API developer portal |
 
 The following optional request headers **MAY** apply.
 
@@ -81,7 +81,7 @@ The following optional request headers **MAY** apply.
 | Date | The date and time at which the message was originated, in "HTTP-date" format as defined by [RFC 7231 Date/Time Formats](http://tools.ietf.org/html/rfc7231#section-7.1.1.1). E.g. `Tue, 15 Nov 1994 08:12:31 GMT`.  |
 | Cookie | An HTTP cookie previously sent by the server. |
 | Cache-Control | Used to specify directives that must be obeyed by all caching mechanisms e.g. no-cache. |
-| If-Match | A string of ASCII characters placed between double quotes.Makes the request conditional. For GET and HEAD methods, the server will send back the requested resource only if it matches one of the listed ETags. For PUT and other non-safe methods, it will only upload the resource in this case.
+| If-Match | A string of ASCII characters placed between double quotes. Makes the request conditional. For GET and HEAD methods, the server will send back the requested resource only if it matches one of the listed ETags. For PUT and other non-safe methods, it will only upload the resource in this case.
 | If-None-Match | A string of ASCII characters placed between double quotes.  For GET and HEAD methods, the server will send back the requested resource, with a 200 status, only if it doesn't have an ETag matching the given ones. For other methods, the request will be processed only if the eventually existing resource's ETag doesn't match any of the values listed. |
 
 Payload data **MUST NOT** be transmitted via HTTP Headers. They are reserved for transversal information (authentication token, monitoring token, request properties etc).

--- a/sections/api-request.md
+++ b/sections/api-request.md
@@ -1,55 +1,9 @@
 ______________________________________________________________________________
 # API Request
 
-## Request Headers
-
-All APIs **MUST** support the following request headers:
-
-| Header | Value |
-| --- | --- |
-| Authorization / Identification | One of: <ul> <li> API Key </li> <li> Basic Auth (APIKey + Secret) </li> <li> Username + Password </li> <li> Bearer {token} </li></ul> |
-
-The following request headers are optional.
-
-| Header | Value |
-| --- | --- |
-| Content-Type | A choice of: <ul> <li> `application/json` (required)</li> <li> `application/xml` (optional for xml)</li> <li> `multipart/form-data` (optional for files) </li> <li> `application/x-www-form-urlencoded` (optional for form data) </li> </ul> |
-| Accept | Content-Types that are acceptable for the response. Choice of: <ul> <li> `application/json` (required) </li> <li> `application/xml` (optional for xml) </li></ul> |
-| Connection | Control options for the current connection. e.g. `keep-alive`. |
-| Date | The date and time at which the message was originated, in "HTTP-date" format as defined by [RFC 7231 Date/Time Formats](http://tools.ietf.org/html/rfc7231#section-7.1.1.1). E.g. `Tue, 15 Nov 1994 08:12:31 GMT`.  |
-| Cookie | An HTTP cookie previously sent by the server. |
-| Cache-Control | Used to specify directives that must be obeyed by all caching mechanisms e.g. no-cache. |
-| ETag | Used to identify the particular version of a resource being updated to prevent multiple user updates. This should match what is currently stored on the server.|
-
-Payload data **MUST** NOT be used in HTTP Headers. They are reserved for transversal information (authentication token, monitoring token, request properties etc).
-
 ## HTTP Request Methods
 
 RESTful API operations are based on the HTTP Request Method standard as defined by [RFC 7231](https://tools.ietf.org/html/rfc7231#section-4.3).
-
-### Supported HTTP request methods
-
-|HTTP Method|Description|
-|---|---|
-| `GET`| To _retrieve_ a resource. |
-| `POST`| To _create_ a new resource, or to _execute_ an operation on a resource that changes the state of the system e.g. send a message. |
-| `PUT`| To _replace_ a resource with another supplied in the request. |
-| `PATCH`| To perform a _partial update_ to a resource. |
-| `DELETE`| To _delete_ a resource. |
-| `HEAD`| For retrieving metadata about the request e.g. how many results _would_ a query return? (without actually performing the query). |
-| `OPTIONS`| Used to determine if a CORS (cross-origin resource sharing) request can be made. This is primarily used in front-end web applications to determine if they can use APIs directly. |
-
-A request to retrieve resources can be made for a single resource or a collection of resources.
-
-Consider the following example:
-
-```
-https://gw.api.gov.au/agency/v1/customers/{id}
-```
-
-To retrieve a collection of customers, a request is sent to the URN `/customers`.
-
-To retrieve a single "customer", a request is sent to the URN `/customers/{id}`.
 
 ### Collection of Resources
 
@@ -62,9 +16,7 @@ The following operations are applicable for a collection of resources:
 
 **Note:**
 
-Creating or updating multiple resource instances in the same request is currently not standardised. There are factors such as receipt acknowledgement and how to handle partial success in a set of batches that must be considered on a case-by-case basis.
-
-Future versions of the specification may address batch processing using APIs.
+Creating or updating multiple resource instances in the same request is not standardised, and should be avoided. There are factors such as receipt acknowledgement and how to handle partial success in a set of batches that add significant complexity.
 
 ### Single Resource
 
@@ -72,18 +24,65 @@ The following operations are applicable for a single resource:
 
 | HTTP method | Resource Path | Operation |
 | --- | --- | --- |
-| GET | `/resources/{id}` | Get the instance corresponding to the resource ID |
-| PUT | `/resources/{id}` | To update a resource instance by replacing it – "_Take this new thing and_ _ **put** _ _it there_" |
+| GET | `/resources/{id}` | Get the instance corresponding to the resource ID e.g. GET https://gw.api.gov.au/agency/v1/customers/1234567 |
+| PUT | `/resources/{id}` | To update a resource instance by replacing it – "_Take this new thing and_ _ **put** _ _it there_". If supported, a PUT method must be implimented with care |
 | DELETE | `/resources/{id}` | To delete the resource instance based on the resource e.g. id |
 | PATCH | `/resources/{id}` | Perform changes such as add, update, and delete to the specified attribute(s). Is used often to perform partial updates on a resource |
 
-## Request Payload Formats
+## Request Document Structure
 
 At minimum the API **MUST** support a `JSON` formatted payload when supplied.
-
 Other payload format such as `XML`, `CSV` and `YAML` may be supported as needed.
+The additional format support must be documented in your API design (Swagger/OpenAPI definition).
 
-The additional format support must be documented in your API design (Swagger definition).
+### Operations on a Business Information Resource
+
+A JSON document passed to a canonical business information resource (POST, PUT, PATCH) SHOULD contain a ‘data’ top-level member to hold the primary data for the request. The 'data' object is NOT required to wrap UI/experience or ‘private’ client-coupled API request data.
+
+The request document MAY also contain a ‘meta’ top-level object if, and only if, it is specifically defined by the API Specification. The ‘meta’ object is used to provide additional information such as second factor authorisation data, copyright, timestamps, origin, ownership, dlm, or other purposes that are complementary to the workings of the API.
+
+e.g.      POST /v1/persons  
+
+```
+{
+   "data": {
+      "familyName": "SMITH",
+      "givenName": "Jane",
+      "sexType": "F",
+      "birthDate": "1992-01-01"
+   }
+}
+```
+
+The ‘resourceId’ payload field is not required (nor should it be supported) when the resource object originates at the client, for either creation of or update to a resource on the server. The unique and immutable resource identifier MUST be managed exclusively by the resource owner.
+
+## Request Headers
+
+All APIs **MUST** support the following request headers:
+
+| Header | Value |
+| --- | --- |
+| Authorization / Identification | One of: <ul> <li> API Key </li> <li> Basic Auth (APIKey + Secret) </li> <li> Username + Password </li> <li> Bearer {token} </li></ul> |
+
+The following request headers **SHOULD** be supported.
+
+| Header | Value |
+| --- | --- |
+| Content-Type | A choice of: <ul> <li> `application/json` (required)</li> <li> `application/xml` (optional for xml)</li> <li> `multipart/form-data` (optional for files) </li> <li> `application/x-www-form-urlencoded` (optional for form data) </li> </ul> |
+| Accept | Content-Types that are acceptable for the response. Choice of: <ul> <li> `application/json` (required) </li> <li> `application/xml` (optional for xml) </li></ul> |
+| Request-Id | A unique identifier for the API request to assist with issue resolution |
+
+The following optional request headers **MAY** apply.
+
+| Header | Value |
+| --- | --- |
+| Connection | Control options for the current connection. e.g. `keep-alive`. |
+| Date | The date and time at which the message was originated, in "HTTP-date" format as defined by [RFC 7231 Date/Time Formats](http://tools.ietf.org/html/rfc7231#section-7.1.1.1). E.g. `Tue, 15 Nov 1994 08:12:31 GMT`.  |
+| Cookie | An HTTP cookie previously sent by the server. |
+| Cache-Control | Used to specify directives that must be obeyed by all caching mechanisms e.g. no-cache. |
+| If-None-Match | A string of ASCII characters placed between double quotes. Matches the content of the server-provided ‘Etag’ header. The client should include this in any update requests to ascertain whether the version of a resource is unchanged. |
+
+Payload data **MUST NOT** be transmitted via HTTP Headers. They are reserved for transversal information (authentication token, monitoring token, request properties etc).
 
 ## Idempotency
 

--- a/sections/api-response.md
+++ b/sections/api-response.md
@@ -61,6 +61,8 @@ A top-level member or root element is not required for a UI/experience, function
 
 ### Operations on a Business Information Resource Instance
 
+A business information resource is a specific data asset acted upon and managed through a state life-cycle by a specific business process. A business information resource will have value outside of its specific sub-domain, and will belong to a System of Record (SoR), the definitive source of the data through all stages of the information life-cycle. Resource models will typically be distilled via a process of Domain Driven Design. Examples of business information resources might include 'accounts' or 'clients'.
+
 A canonical business information resource response document SHOULD contain at least one of the following top-level members:
 
 | Status | Top-Level Member |

--- a/sections/api-response.md
+++ b/sections/api-response.md
@@ -105,7 +105,6 @@ The following response headers **SHOULD** be included in all responses:
 | --- | --- |
 | Location | path of the newly created resource. e.g. 'v1/persons/65648987235' |
 | Content-Type | Choice of: <ul> <li>`application/json` (required)</li> <li>`application/xml` (optional for `xml`)</li> <li>`multipart/form-data` (optional for files)</li> <li>`text/html` (optional for `html`)</li> </ul> |
-| Request-Id | If a request ID was provided by the client in the request, it SHOULD be returned in the response |
 
 The following response headers **MAY** be included in responses:
 

--- a/sections/api-response.md
+++ b/sections/api-response.md
@@ -61,7 +61,7 @@ A top-level member or root element is not required for a UI/experience, function
 
 ### Operations on a Business Information Resource Instance
 
-A business information resource is a specific data asset acted upon and managed through a state life-cycle by a specific business process. A business information resource will have value outside of its specific sub-domain, and will belong to a System of Record (SoR), the definitive source of the data through all stages of the information life-cycle. Resource models will typically be distilled via a process of Domain Driven Design. Examples of business information resources might include 'accounts' or 'clients'.
+A business information resource is a specific data asset acted upon and managed through a state life-cycle by a specific business process. A business information resource will have value outside of its specific sub-domain, and will belong to a System of Record (SoR), the definitive source of the data through all stages of the resource life-cycle. Resource models will typically be distilled via a process of Domain Driven Design. Examples of business information resources might include 'accounts' or 'clients'.
 
 A canonical business information resource response document SHOULD contain at least one of the following top-level members:
 

--- a/sections/api-response.md
+++ b/sections/api-response.md
@@ -1,18 +1,121 @@
 ______________________________________________________________________________
 # API Responses
 
+## Response Document Structure
+
+The returned media type MUST conform to the value provided in the API request Accept header, or the 1st supported media type if multiple values are specified. The default content type is JSON (application/json).
+
+If the requested media type(s) are unsupported, the server MUST return an HTTP response status 415 Unsupported Media Type.
+
+### Operations on a Resource Collection
+A GET performed on a resource collection (without specifying a resource Id) will return potentially multiple resource instances, and MUST return the collection in a "data" array, which provides a predictable document path to resource data. The data array must be returned even when the response is a collection of one.
+
+e.g.      GET /v1/persons  
+
+Response
+
+```
+// 200 OK
+Content-Type: application/json; charset=utf-8
+
+{
+   "data": [
+       {
+           "applicationId": "65648987234",
+           "familyName": "SMITH",
+           "givenName": "John",
+           "birthDate": "1990-01-01"
+       },
+       {
+           "applicationId": "878795465",
+           "familyName": "DOE",
+           "givenName": "Jane",
+           "birthDate": "1986-03-01"
+       }
+   ]
+}
+```
+
+NOTE: Arrays containing very large datasets or large binary objects, such as documents or images, MUST be controlled by pagination. Total payload size MUST NOT exceed 10 Mb. It is suggested that payload size SHOULD NOT exceed 2 Mb, an historical default payload maximum for a number of platforms.
+
+A POST may also be performed on a resource collection to create a new instance of the resource. A unique and immutable resource identifier MUST be created and returned by the resource owner and SHOULD be returned as a payload field  in the form of '{resourceName}Id' or '{resourceName}_id'. Additional derived data MAY be returned as deemed appropriate. The server MUST return a ‘Location’ header containing the relative path of the newly created resource, e.g. '/persons/65648987235'. A links object MAY be returned if required, for instance to return a version link in cases where a versioned change history is maintained.
+
+e.g.  POST /v1/persons
+
+Response
+
+```
+// 201 Created
+Content-Type: application/json; charset=utf-8
+Location: /persons/65648987235
+{
+   "data": {      
+      "personId": "65648987235",
+   }
+}
+```
+
+### Operations on a UI/Experience Resource Instance
+
+A top-level member or root element is not required for a UI/experience, functional or 'private' API response document unless the request is unsuccessful, in which case an ‘errors‘ collection - an array of error objects - SHOULD be returned, as outlined in the Error Handling section of this standard.
+
+### Operations on a Business Information Resource Instance
+
+A canonical business information resource response document SHOULD contain at least one of the following top-level members:
+
+| Status | Top-Level Member |
+| --- | --- |
+| Success (200, 201) | SHOULD contain a top-level ‘data‘ object <br />SHOULD contain a ‘links‘ object – HATEOAS links to sub-resources, including, at a minimum, a ‘self’ reference. <br />MAY contain a ‘meta‘ object - a meta object that contains non-standard meta-information. <br />MAY contain a ‘messages‘ object – container for informational and warning messages related to the transaction.|
+| Unsuccessful (4xx, 5xx) | MUST contain an ‘errors‘ object - an array of error objects. |
+
+The members ‘data’ and ‘errors’ MUST NOT coexist in the same document.
+
+A GET request to the parent resource SHOULD return root-level resource data only, SHOULD provide links to identify sub-resources, and MAY provide links to identify existentially related objects.
+
+The ‘meta’ top-level element provides a mechanism for the provision of meta-data, such as copyright, timestamp, origin, ownership, and dissemination delimiter. If a ‘meta’ member is to be returned, its content MUST be defined in the API specification.
+
+Example response document:
+
+```
+{
+    "meta": {
+        "dlm": "sensitive:personal",
+        "copyright": "Copyright 2015 Example Corp.", 
+        "totalPages": 13
+    }
+    "data": {  
+        "documentId": "3456789", 
+        "title": "declaration", 
+        "uploaded": "2018-05-22T14:56:29.000Z", 
+        "updated": "2015-05-22T14:56:28.000Z 
+    }
+    "links": {
+        "self": "http://example.com/v1/documents/3456789"
+    }
+}
+```
+
 ## Response Headers
 
-The recommended content type is `JSON` (`application/json`).
+The recommended, and default content type is `JSON` (`application/json`).
 
-The following response headers **MAY** be included in all responses:
+The following response headers **SHOULD** be included in all responses:
+
+| Header | Value |
+| --- | --- |
+| Location | path of the newly created resource. e.g. 'v1/persons/65648987235' |
+| Content-Type | Choice of: <ul> <li>`application/json` (required)</li> <li>`application/xml` (optional for `xml`)</li> <li>`multipart/form-data` (optional for files)</li> <li>`text/html` (optional for `html`)</li> </ul> |
+| Request-Id | If a request ID was provided by the client in the request, it SHOULD be returned in the response |
+
+The following response headers **MAY** be included in responses:
 
 | Header | Value |
 | --- | --- |
 | Access-Control-Allow-Origin | The URL that is allowed to access this service from javascript and browser based clients directly.<br/><br/> **Note:** Never use wildcard (*) URLs unless the REST resource is truly public. |
 | Access-Control-Allow-Methods | The methods that are allowed to be accessed from javascript and browser based clients directly. |
 | Access-Control-Allow-Headers | The headers that are allowed to be accessed from javascript and browser based clients directly. |
-| Content-Type | Choice of: <ul> <li>`application/json` (required)</li> <li>`application/xml` (optional for `xml`)</li> <li>`multipart/form-data` (optional for files)</li> <li>`text/html` (optional for `html`)</li> </ul> |
+| x-protective-marking | Should be provided when the message payload contains data classified at ‘OFFICIAL’ or above. The values of the header should align with the appropriate Security classification literals defined buy the owning jurisdiction |
+| Link | WebSub link headers required to support dynamic subscription to the WebSub hub. Compirsed of relationship type “self” (topic) and “hub” (subscription endpoint) e.g. <persons/12345/events>; rel="self", <persons/events/subscribe>; rel="hub" |
 | Cache-Control | Informs the caching mechanisms. It is measured in seconds.max-age=3600 |
 | Date | The date and time that the message was originated Date  e.g. Tue, 15 Nov 1994 08:12:31 GMT |
 | Expires | Gives the date/time after which the response is considered stale  e.g. Thu, 01 Dec 1994 16:00:00 GMT |
@@ -20,140 +123,25 @@ The following response headers **MAY** be included in all responses:
 
 ## HTTP Response Codes
 
-The following table defines the responses that **MUST** be supported by your API.
+Not all HTTP status codes are mandatory, or will apply to every operation. The table below indicates the HTTP Response codes that SHOULD be supported at a minimum for each HTTP method.
 
-| Request Method | Status | Code | When to use |
-| --- | --- | --- | --- |
-| GET | OK | 200 | The request was successfully processed |
-| GET | Bad Request | 400 | The server cannot process the request (such as malformed request syntax, size too large, invalid request message framing, or deceptive request routing, invalid values in the request) |
-|GET| Unauthorised | 401 | The request could not be authenticated. |
-|GET| Forbidden | 403 | The request was authenticated but is not authorised to access the resource. |
-|GET| Not found | 404 | The resource was not found. |
-|GET| Not Allowed | 405 | The method is not implemented for this resource. The response may include an Allow header containing a list of valid methods for the resource. |
-|GET| Unsupported Media Type | 415 | This status code indicates that the server refuses to accept the request because the content type specified in the request is not supported by the server |
-|GET| Internal Server error | 500 | An internal server error. The response body may contain error messages. |
+| Code | Description | POST /resources | GET /resources | GET /resources/{id} | PUT /resources/{id} | DELETE /resources/{id} | PATCH /resources/{id} |
+| --- | ---------------------- | :-: | :-: | :-: | :-: | :-: | :-: |
+| 200 | OK                     |   | √ | √ | √ |   |   |
+| 201 | Created                | √ |   |   |   |   |   |
+| 202 | Accepted               | √ |   |   | √ | √ | √ |
+| 204 | No content             |   |   |   | √ | √ | √ |
+|     |                        |  
+| 400 | Bad Request            | √ | √ | √ | √ | √ | √ |
+| 401 | Unauthorised           | √ | √ | √ | √ | √ | √ |
+| 403 | Forbidden              | √ | √ | √ | √ | √ | √ |
+| 404 | Not found              | √ | √ | √ | √ | √ | √ |
+| 405 | Not Allowed            | √ | √ | √ | √ | √ | √ |
+| 408 | Request Timeout        | √ | √ | √ | √ | √ | √ |
+| 415 | Unsupported Media Type | √ | √ | √ | √ |   | √ |
+| 422 | Unprocessable Entity   | √ |   |   | √ |   | √ |
+|     |                        |
+| 500 | Internal Server Error  | √ | √ | √ | √ | √ | √ |
+| 501 | Method Not Implemented | √ |   |   | √ | √ | √ |
 
-| Request Method | Status | Code | When to use |
-| --- | --- | --- | --- |
-| POST | Created | 201 | The resource was created. The Response Location HTTP header **SHOULD** be returned to indicate where the newly created resource is accessible. |
-|POST| Accepted | 202 | Is used for asynchronous processing to indicate that the server has accepted the request but the result is not available yet. The Response Location HTTP header may be returned to indicate where the created resource will be accessible. |
-|POST| Bad Request | 400 | The server cannot process the request (such as malformed request syntax, size too large, invalid request message framing, or deceptive request routing, invalid values in the request) For example, the API requires a numerical identifier and the client sent a text value instead, the server will return this status code. |
-|POST| Unauthorised | 401 | The request could not be authenticated. |
-|POST| Forbidden | 403 | The request was authenticated but is not authorised to access the resource. |
-|POST| Not found | 404 | The resource was not found. |
-|POST| Not Allowed | 405 | The method is not implemented for this resource. The response may include an Allow header containing a list of valid methods for the resource. |
-|POST| Unsupported Media Type | 415 | This status code indicates that the server refuses to accept the request because the content type specified in the request is not supported by the server |
-|POST| Unprocessable Entity | 422 | This status code indicates that the server received the request but it did not fulfil the requirements of the back end. An example is a mandatory field was not provided in the payload. |
-|POST| Internal Server error | 500 | An internal server error. The response body may contain error messages. |
-
-| Request Method | Status | Code | When to use |
-| --- | --- | --- | --- |
-| PUT | Accepted | 202 | Is used for asynchronous processing to indicate that the server has accepted the request but the result is not available yet. |
-|PUT| No content | 204 | The server successfully processed the request and is not returning any content |
-|PUT| Bad Request | 400 | The server cannot process the request (such as malformed request syntax, size too large, invalid request message framing, or deceptive request routing, invalid values in the request)For example, the API requires a numerical identifier and the client sent a text value instead, the server will return this status code. |
-|PUT| Unauthorised | 401 | The request could not be authenticated. |
-|PUT| Forbidden | 403 | The request was authenticated but is not authorised to access the resource. |
-|PUT| Not found | 404 | The resource was not found. |
-|PUT| Not Allowed | 405 | The method is not implemented for this resource. The response may include an Allow header containing a list of valid methods for the resource. |
-|PUT| Unsupported Media Type | 415 | This status code indicates that the server refuses to accept the request because the content type specified in the request is not supported by the server |
-|PUT| Unprocessable Entity | 422 | This status code indicates that the server received the request but it did not fulfil the requirements of the back end. An example is a mandatory field was not provided in the payload. |
-|PUT| Internal Server error | 500 | An internal server error. The response body may contain error messages. |
-
-| Request Method | Status | Code | When to use |
-| --- | --- | --- | --- |
-| DELETE | Accepted | 202 | Is used for asynchronous processing to indicate that the server has accepted the request but the result is not available yet. |
-|DELETE| No content | 204 | The server successfully processed the request and is not returning any content |
-|DELETE| Bad Request | 400 | The server cannot process the request (such as malformed request syntax, size too large, invalid request message framing, or deceptive request routing, invalid values in the request) |
-|DELETE| Unauthorised | 401 | The request could not be authenticated. |
-|DELETE| Forbidden | 403 | The request was authenticated but is not authorised to access the resource. |
-|DELETE| Not found | 404 | The resource was not found. |
-|DELETE| Not Allowed | 405 | Method not allowed on resource. The response may include an Allow header containing a list of valid methods for the resource. |
-|DELETE| Unsupported Media Type | 415 | This status code indicates that the server refuses to accept the request because the content type specified in the request is not supported by the server |
-|DELETE| Internal Server error | 500 | An internal server error. The response body may contain error messages. |
-
-| Request Method | Status | Code | When to use |
-| --- | --- | --- | --- |
-| PATCH | Accepted | 202 | Is used for asynchronous processing to indicate that the server has accepted the request, but the result is not available yet. |
-|PATCH| No content | 204 | The server successfully processed the request and is not returning any content |
-|PATCH| Bad Request | 400 | The server cannot process the request (such as malformed request syntax, size too large, invalid request message framing, or deceptive request routing, invalid values in the request) For example, the API requires a numerical identifier and the client sent a text value instead, the server will return this status code. |
-|PATCH| Unauthorised | 401 | The request could not be authenticated. |
-|PATCH| Forbidden | 403 | The request was authenticated but is not authorised to access the resource. |
-|PATCH| Not found | 404 | The resource was not found. |
-|PATCH| Not Allowed | 405 | The method is not implemented for this resource. The response may include an Allow header containing a list of valid methods for the resource. |
-|PATCH| Unsupported Media Type | 415 | It indicates that the server refuses to accept the request because the content type specified in the request is not supported by the server |
-|PATCH| Unprocessable Entity | 422 | This status code indicates that the server received the request but it did not fulfil the requirements of the back end. An example is a mandatory field was not provided in the payload. |
-|PATCH| Internal Server error | 500 | An internal server error. The response body may contain error messages. |
-
-This table highlights the status codes that are applicable for all HTTP Methods
-
-| Request Method | Status | Code | When to use |
-| --- | --- | --- | --- |
-| All | Request Timeout | 408 | The request timed out before a response was received. |
-| All | Method Not Implemented | 501 | It indicates that the request method is not supported by the server and cannot be handled for **any** resource. For example, the server supports GET, POST, PUT, DELETE, and PATCH but not OPTIONS methods. |
-
-## Response Payload
-
-The Response payload for an API can be for a single resource or a collection of resources.
-
-When the response format is `JSON`, the following response standards apply:
-
-### Single Resource
-
-The following status codes represent appropriate responses to the different operations that can be performed on a single resource within the system.
-
-| Request Method | Resource Path | Status | Code |
-| --- | --- | --- | --- |
-| POST | `/resources/{id}` | Created | 201 | 
-||| Accepted | 202 |
-||| Bad Request | 400 |
-||| Unauthorised | 401 | 
-||| Forbidden | 403 | 
-||| Not found | 404 | 
-||| Not Allowed | 405 | 
-||| Unsupported Media Type | 415 | 
-||| Unprocessable Entity | 422 |
-||| Internal Server Error | 500 | 
-| PUT | `/resources/{id}` | OK | 200 |
-||| Accepted | 202 |
-||| No content | 204 | 
-||| Bad Request | 400 | 
-||| Unauthorised | 401 | 
-||| Forbidden | 403 | 
-||| Not found | 404 | 
-||| Not Allowed | 405 | 
-||| Unsupported Media Type | 415 | 
-||| Unprocessable Entity | 422 |
-||| Internal Server error | 500 | 
-| DELETE | `/resources/{id}` | Accepted | 202 | 
-||| No Content | 204 |
-||| Bad Request | 400 | 
-||| Unauthorised | 401 | 
-||| Forbidden | 403 | 
-||| Not found | 404 | 
-||| Not Allowed | 405 | 
-||| Internal Server error | 500 | 
-| PATCH | `/resources/{id}` | Accepted | 202 | 
-||| No content | 204 | 
-||| Bad Request | 400 | 
-||| Unauthorised | 401 | 
-||| Forbidden | 403 | 
-||| Not found | 404 | 
-||| Not Allowed | 405 | 
-||| Unsupported Media Type | 415 | 
-||| Unprocessable Entity | 422 |
-||| Internal Server error | 500 |
-
-### Collection of Resources
-
-The following status codes represent appropriate responses to the different operations that can be performed on a collection resource within the system.
-
-| Request Method | Resource Path | Status | Code |
-| --- | --- | --- | --- | 
-| GET | `/resources/` | OK | 200 |
-||| Bad Request | 400 | 
-||| Unauthorised | 401 | 
-||| Forbidden | 403 | 
-||| Not found | 404 | 
-||| Not Allowed | 405 | 
-||| Unsupported Media Type | 415 | 
-||| Internal Server error | 500 |
+Status Code Definitions and their correct application are defined by [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)

--- a/sections/api-versioning.md
+++ b/sections/api-versioning.md
@@ -32,13 +32,13 @@ When new major versions are published the older version must be deprecated follo
 
 ## Minor Version
 
-Minor version numbers are displayed on the API documentation page or part of a special management call to the API URI itself. To support this your API **MUST** implement a response to a GET request to the base URI of the API and return the following metadata in the response:
+Minor version numbers are displayed on the API documentation page or part of a special management call to the API URI itself. To support this your API **SHOULD** implement a response to a GET request to the base URI of the API and return the following metadata in the response:
 
-- **api_name:** The API Name
-- **api_version:** The API Version with major and minor versions
-- **api_released:** The date the API was released
-- **api_documentation:** Links to the API Documentation
-- **api_status:** To indicate whether an API is still active or has been deprecated.
+- **api_name** or **apiName** :  The API Name
+- **api_version** or **apiVersion** : The API Version with major and minor versions
+- **api_released** or **apiReleased** : The date the API was released
+- **api_documentation:** or **apiDocumentation** : Links to the API Documentation
+- **api_status** or **apiStatus** " To indicate whether an API is still active or has been deprecated.
 
 Additional metadata can be added to the response if required.
 


### PR DESCRIPTION
PROVISIONAL on a decision to align with CDS
Provides guidance on the use of 'data' and 'meta' headers, and when they should apply.

Additional updates:

‘Etag’ header does not apply to requests, replaced with client-side 'If-None-Match'
addition of optional 'Request-Id' header for tracability
replaced status code definitions with a reference to https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
replaced voluminous response code tables with a more readable matrix